### PR TITLE
feat: Implement Commet CRUD featrues

### DIFF
--- a/src/main/java/com/example/crudboard/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/crudboard/config/WebSecurityConfig.java
@@ -23,7 +23,8 @@ public class WebSecurityConfig {
                                 "/api/boards/**",  // api/boards 및 그 하위 모든 경로 허용
                                 "/api/posts",  // 모든 게시글 목록 조회 및 허용
                                 "/api/posts/search",  // 게시글 검색 허용
-                                "/api/posts/{postId}"  // 특정 게시글 조회 허용
+                                "/api/posts/{postId}",  // 특정 게시글 조회 허용
+                                "api/comments/**"
                         ).permitAll()
                         // 그 외 모든 요청은 인증된 사용자만 접근을 허용한다.
                         .anyRequest().authenticated()
@@ -31,3 +32,5 @@ public class WebSecurityConfig {
         return http.build();
     }
 }
+
+// 추후 PUT(수정), DELETE(삭제) API는 인증된 사용자만 접근할 수 있도록 설정 필요 - 현재는 기능 테스트 중으로 모두 허용

--- a/src/main/java/com/example/crudboard/controller/CommentController.java
+++ b/src/main/java/com/example/crudboard/controller/CommentController.java
@@ -1,0 +1,169 @@
+package com.example.crudboard.controller;
+
+import com.example.crudboard.domain.Comment;
+import com.example.crudboard.service.CommentService;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+// 댓글 요청을 받을 DTO
+@Getter
+@Setter
+class CommentRequestDto {
+    private Long postId;  // 댓글이 속할 게시글 ID
+    private Long userId;  // 댓글 작성자 ID
+    private String content;  // 댓글 내용
+}
+
+// 댓글 응답 데이터를 담을 DTO
+@Getter
+@RequiredArgsConstructor
+class CommentResponseDto {
+    private final Long commentId;
+    private final Long postId;
+    private final Long userId;
+    private final String content;
+    private final int likeCount;
+    private final int hateCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public CommentResponseDto (Comment comment) {
+        this.commentId = comment.getCommentId();
+        this.postId = comment.getPost().getPostId();
+        this.userId = comment.getUser().getUserId();
+        this.content = comment.getContent();
+        this.likeCount = comment.getLikeCount();
+        this.hateCount = comment.getHateCount();
+        this.createdAt = comment.getCreatedAt();
+        this.updatedAt = comment.getUpdatedAt();
+    }
+}
+
+// 페이지네이션된 댓글 목록 응답을 위한 DTO
+@Getter
+@RequiredArgsConstructor
+class CommentPageResponseDto {
+    private final List<CommentResponseDto> content;
+    private final int totalPages;
+    private final long totalElements;
+    private final int currentPage;
+    private final int pageSize;
+    private final boolean hasNext;
+    private final boolean hasPrevious;
+
+    public CommentPageResponseDto(Page<Comment> commentPage) {
+        this.content = commentPage.getContent().stream().map(CommentResponseDto::new).collect(Collectors.toList());
+        this.totalPages = commentPage.getTotalPages();
+        this.totalElements = commentPage.getTotalElements();
+        this.currentPage = commentPage.getNumber();
+        this.pageSize = commentPage.getSize();
+        this.hasNext = commentPage.hasNext();
+        this.hasPrevious = commentPage.hasPrevious();
+    }
+}
+
+@RestController  // RESTful API 컨트롤러임을 알림
+@RequiredArgsConstructor  // final 필드를 자동으로 주입받는 생성자
+@RequestMapping("/api/comments")  // 이 컨트롤러의 기본 URL 경로를 설정
+public class CommentController {
+
+    private final CommentService commentService;  // @ReauiredArgsConstructor에 의해 자동으로 주입받아 생성자 코드를 구현하지 않고도 사용 가능
+
+    /*
+    * 새로운 댓글 생성 API
+    * @POST /api/comments
+    * @param requestDto 생성할 댓글 정보(postId, userId, content)
+    * @return 생성된 Comment 정보 (201 CREATED)
+    * */
+    @PostMapping
+    public ResponseEntity<CommentResponseDto> createComment(@RequestBody CommentRequestDto requestDto) {
+        try {
+            Comment newComment = commentService.createComment(
+                    requestDto.getPostId(),
+                    requestDto.getUserId(),
+                    requestDto.getContent()
+            );
+            return new ResponseEntity<>(new CommentResponseDto(newComment), HttpStatus.CREATED);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    /*
+    * 특정 게시글의 모든 댓글 목록 조회 API (페이지네이션 적용)
+    * GET /api/comments/post/{postId}?page={page}&size={size}
+    * @param postId 댓글을 조회할 게시글 ID
+    * @param page 페이지 번호 (기본값 0)
+    * @param sizze 한 페이지당 댓글 수 (기본값 5)
+    * @return 페이지네이션된 Comment 목록 (200 OK)
+    * */
+    @GetMapping("/post/{postId}")
+    public ResponseEntity<CommentPageResponseDto> getCommentsByPostId(@PathVariable Long postId, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "5") int size) {
+        try {
+            Page<Comment> commentPage = commentService.findCommentsByPostId(postId, page, size);
+            return new ResponseEntity<>(new CommentPageResponseDto(commentPage), HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    /*
+    * 특정 ID의 댓글 조회 API
+    * GET /api/comments/{commentId}
+    * @param commentId 조회할 댓글 ID
+    * @return 조회된 Comment 정보 (200 OK)
+    * */
+    @GetMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDto> getCommentById(@PathVariable Long commentId) {
+        try {
+            Comment comment = commentService.getCommentById(commentId);
+            return new ResponseEntity<>(new CommentResponseDto(comment), HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    /*
+    * 댓글 수정 API
+    * PUT /api/comments/{commentId}
+    * @param commentId 댓글 ID
+    * @param newContent 수정할 내용
+    * @return 수정된 Comment 정보 (200 OK)
+    * */
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDto> updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDto requestDto) {
+        try {
+            Comment updateComment = commentService.updateComment(commentId,requestDto.getUserId(), requestDto.getContent());  // userId를 통해 권한 확인
+            return new ResponseEntity<>(new CommentResponseDto(updateComment), HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);  // 권한 없음 또는 댓글을 찾을 수 없음
+        }
+    }
+
+    /*
+    * 특정 ID의 댓글 삭제 API
+    * DELETE /api/comments/{commentId}
+    * @param commentId 삭제할 댓글 ID
+    * @param userId 삭제 요청 사용자 ID (권한 확인용)
+    * @return 삭제 성공 메시지
+    * */
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, @RequestParam Long userId) {  // Delete 요청의 경우 일반적으로 Body를 포함하지 않는다. userId는 삭제 권한 확인을 위한 정보이므로 URL쿼리 파라미터로 받는 것이 RESTful API관례에 더 적합하다.
+        try {
+            commentService.deleteComment(commentId, userId);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } catch (IllegalArgumentException e){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);  // 권한 없음 또는 댓글을 찾을 수 없음
+        }
+    }
+}

--- a/src/main/java/com/example/crudboard/repository/CommentRepository.java
+++ b/src/main/java/com/example/crudboard/repository/CommentRepository.java
@@ -1,0 +1,25 @@
+package com.example.crudboard.repository;
+
+import com.example.crudboard.domain.Comment;
+import com.example.crudboard.domain.Post;  // 특정 게시글의 댓글 조회를 위해 필요
+import com.example.crudboard.domain.User;  // 특정 사용자의 댓글 조회를 위해 필요
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;  // 페이지네이션을 위한 Page 객체
+import org.springframework.data.domain.Pageable;  // 페이지네이션 정보를 위한 Pageable 객체
+import java.util.Optional;
+
+public interface CommentRepository extends  JpaRepository<Comment, Long>{
+
+    // 특정 게시글(Post)에 속하는 모든 댓글을 페이지 단위로 조회한다.
+    // 게시글 상세 페이지에서 댓글 목록을 보여줄 때 사용된다.
+    Page<Comment> findByPost(Post post, Pageable pageable);
+
+    // 특정 사용자(User)가 작성한 모든 댓글을 페이지 단위로 조회한다.
+    Page<Comment> findByUser(User user, Pageable pageable);
+
+    // 특정 CommentId를 가진 댓글이 특정 사용자가 작성한 댓글인지 확인 (댓글 수정/삭제 권한 확인)
+    Optional<Comment> findByCommentIdAndUser(Long commentId, User user);
+
+    // 특정 게시글에 특정 사용자가 작성한 댓글이 있는지 확인
+    Optional<Comment> findByPostAndUser(Post post, User user);
+}

--- a/src/main/java/com/example/crudboard/service/CommentService.java
+++ b/src/main/java/com/example/crudboard/service/CommentService.java
@@ -1,0 +1,109 @@
+package com.example.crudboard.service;
+
+import com.example.crudboard.domain.Comment;
+import com.example.crudboard.domain.User;
+import com.example.crudboard.domain.Post;
+import com.example.crudboard.repository.CommentRepository;
+import com.example.crudboard.repository.UserRepository;
+import com.example.crudboard.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    /*
+    * 새로운 댓글을 생성한다.
+    * @param postId 게시글 고유 ID
+    * @param userId 사용자 고유 ID
+    * @param conetent 댓글 내용
+    * @return 생성된 Comment 엔티티
+    * @throws IllegalArgumentException (게시글 또는 사용자를 찾을 수 없을 경우 발생)
+    * */
+    @Transactional
+    public Comment createComment(Long postId, Long userId, String content) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 게시글을 찾을 수 없습니다."));
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다."));
+
+        Comment newComment = new Comment(post, user, content);
+        return commentRepository.save(newComment);  // 데이터베이스에 저장 및 리턴
+    }
+
+    /*
+    * 특정 게시글에 속하는 모든 댓글을 페이지 단위로 조회한다.
+    * @param postId 댓글을 조회할 게시글 ID
+    * @param page 페이지 번호(0부터 시작)
+    * @param size 한 페이지당 댓글 수
+    * @return 페이지네이션된 Comment 엔티티 목록
+    * @throws IllegalArgumentException 게시글을 찾을 수 없을 경우 발생
+    * */
+    public Page<Comment> findCommentsByPostId(Long postId, int page, int size) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 게시글을 찾을 수 없습니다."));
+
+        // 최신 댓글이 먼저 오도록 createdAt 기준으로 내림차순 정렬
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return commentRepository.findByPost(post, pageable);
+    }
+
+    /*
+    * 특정 ID의 댓글을 조회한다.
+    * @param commentId 조회할 댓글 ID
+    * @return 조회된 Comment 엔티티
+    * @throws IllegalArgumentException 해당 ID의 댓글을 찾을 수 없을 경우 발생
+    * */
+    public Comment getCommentById(Long commentId){
+        return commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 댓글을 찾을 수 없습니다."));
+    }
+
+    /*
+    * 댓글을 수정한다.
+    * @param commentId 수정할 댓글 ID
+    * @param userId 댓글 작성자 ID (권한 확인)
+    * @param newContent 새로운 댓글 내용
+    * @return 수정된 Comment 엔티티
+    * @throws IllegalArgumentException 해당 ID의 댓글을 찾을 수 없거나, 작성자가 일치하지 않을 경우
+    * */
+    @Transactional
+    public Comment updateComment(Long commentId, Long userId, String newContent){
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 댓글을 찾을 수 없습니다."));
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다."));
+
+        // 댓글 작성자가 아닐 경우
+        if (!comment.getUser().getUserId().equals(user.getUserId())) {
+            throw new IllegalArgumentException("댓글을 수정할 권한이 없습니다.");
+        }
+
+        comment.updateComment(newContent);
+        return comment;
+    }
+
+    /*
+    * 댓글을 삭제한다. (관리자, 댓글 작성자만 가능)
+    * @param commentId 삭제할 댓글 ID
+    * @param userId 댓글 작성자 ID (권한 확인용)
+    * @throws IllegalArgumentException 해당 ID의 댓글을 찾을 수 없거나, 작성자가 일치하지 않ㅇ르 경우 발생
+    * */
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 댓글을 찾을 수 없습니다."));
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다."));
+
+        // 권한 확인
+        if (!comment.getUser().getUserId().equals(user.getUserId())){
+            throw new IllegalArgumentException("댓글을 삭제할 권한이 없습니다.");
+        }
+
+        commentRepository.delete(comment);  // 데이터베이스에서 댓글 삭제
+    }
+}


### PR DESCRIPTION
## 댓글 CRUD 기능 구현 완료

### 구현 내용
- **`Comment Repository, Service, Controller 및 DTO 작성**:
    - `CommentRepository`: `JpaRepository` 상속 및 `findByPost`, `findByUser` 등 댓글 조회 및 검색을 위한 쿼리 메서드 정의.
    - `CommentService`: 댓글 생성, 특정 게시글 댓글 조회, 특정 댓글 조회, 댓글 수정, 댓글 삭제 비즈니스 로직 구현. (댓글 수정/삭제 시 작성자 권한 확인 로직 포함)
    - `CommentController`: 댓글 생성(POST), 특정 게시글 댓글 목록 조회(GET), 특정 댓글 조회(GET), 댓글 수정(PUT), 댓글 삭제(DELETE) API 엔드포인트 정의.
    - `CommentRequestDto`, `CommentResponseDto`, `CommentPageResponseDto` DTO 클래스 정의.

### 주요 변경사항
- `WebSecurityConfig` 업데이트: `/api/comments/**` 경로에 대한 `GET` 및 `POST` 요청을 `permitAll()`로 허용하여 인증 없이 접근 가능하도록 설정.
    - (참고: `PUT`, `DELETE` 요청은 `authenticated()` 규칙에 따라 인증된 사용자만 접근 가능하며, `CommentService`에서 작성자 권한을 추가로 확인합니다.)

### 테스트 완료
- Postman을 통해 다음 API들의 정상 동작을 확인했습니다:
    - `POST /api/comments` (댓글 생성)
    - `GET /api/comments/post/{postId}` (특정 게시글의 댓글 목록 조회)
    - `GET /api/comments/{commentId}` (특정 댓글 조회)
    - `PUT /api/comments/{commentId}` (댓글 수정)
    - `DELETE /api/comments/{commentId}` (댓글 삭제)

---